### PR TITLE
Replace tones list with degree->tone dict

### DIFF
--- a/lib/scale.py
+++ b/lib/scale.py
@@ -23,45 +23,60 @@ class Scale(object):
         :param root_note: Note object, root note for the scale (default None)
         :param tones: List of tones, each tone the number of cents above root
         """
-        self.__tones = [0]
+        # First degree is always the root
+        self.__degrees = {1: 0}
         self.__root_note = None
 
         self.root_note = root_note
-        if isinstance(tones, (list,)):
+        if tones is not None and isinstance(tones, (list,)):
             try:
                 for tone in sorted(tones):
                     self.add_tone(tone)
             except TypeError:
                 pass
 
+
+    @property
+    def degrees(self):
+        return self.__degrees
+
     @property
     def tones(self):
         """
-        getter for self.__tones
-        :return: self.__tones
+        Get the tones of the scale, in cents above root
+        :return: A sorted list of tones in the scale
         """
-        return self.__tones
+        return sorted(list(self.degrees.values()))
 
     def add_tone(self, cents):
         """
         Add a tone to the scale
         :param cents: difference from scale root, in cents
-        :return: new position of the tone in the scale
+        :return: new degree of the tone in the scale
                  None if invalid cents value
                  -1 if tone already exists in the scale
-        Raises ValueError if cents out of range
         """
+        my_tones = self.tones
         try:
             float(cents)
         except ValueError:
             return None
         if cents < MIN_CENTS:
             return None
-        if cents in self.tones:
+        if cents in my_tones:
             return -1
-        new_position = bisect.bisect(self.tones, cents)
-        bisect.insort(self.__tones, cents)
-        return new_position
+        #new_position = bisect.bisect(self.tones, cents)
+        #bisect.insort(self.__tones, cents)
+        my_tones.append(cents)
+        # Rebuild self.__degrees dictionary
+        i = 1
+        self.__degrees = dict()
+        for tone in sorted(my_tones):
+            self.__degrees[i] = tone
+            if tone == cents:
+                new_degree = i
+            i += 1
+        return new_degree
 
     @property
     def root_note(self):

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -1,9 +1,14 @@
 """
 scale.py
 A class to hold a collection of tones defined as a scale
-(ie all tones within an octave range)
-The scale is defined by relative distances between
-each of the tones and the root
+(ie all tones within an octave range).
+
+The scale is defined by relative distances between each of the tones and the
+root.
+The base structure of the scale is provided by degree_tones. This is a
+dictionary of degree: tone, where 'degree' is the degree of the scale
+(with the root being 1) and 'tone' is the number of cents above the root for
+the degree.
 """
 
 import bisect

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -120,7 +120,23 @@ class Scale(object):
         new_degree = self.add_tone(self.degree_tones[degree] + cents)
         return new_degree
 
+    def move_degree(self, degree, cents):
+        """
+        Move (retune) a degree by cents
+        :param degree: the scale degree to retune
+        :param cents: the number of cents by which to change the tone
+        (can be negative)
+        :return:
+        """
+        # FIXME: stub
+        return
+
     def remove_degree(self, degree):
+        """
+        Remove a scale degree
+        :param degree:
+        :return: 0 on success, -1 on error
+        """
         # FIXME: stub
         return
 

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -120,6 +120,10 @@ class Scale(object):
         new_degree = self.add_tone(self.degree_tones[degree] + cents)
         return new_degree
 
+    def remove_degree(self, degree):
+        # FIXME: stub
+        return
+
     @property
     def root_note(self):
         """

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -82,6 +82,7 @@ class Scale(object):
                  -1 if tone already exists in the scale
         """
         my_tones = self.tones
+        new_degree = None
         try:
             float(cents)
         except ValueError:
@@ -101,6 +102,13 @@ class Scale(object):
             if tone == cents:
                 new_degree = i
             i += 1
+        return new_degree
+
+    def add_tone_above_degree(self, degree, cents):
+        new_degree = None
+        if degree not in self.degrees:
+            return -1
+        new_degree = self.add_tone(self.degree_tones[degree] + cents)
         return new_degree
 
     @property

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -2,8 +2,8 @@
 scale.py
 A class to hold a collection of tones defined as a scale
 (ie all tones within an octave range)
-By default, the scale is defined by relative distances between the tones
-(in cents), unless a root note is defined.
+The scale is defined by relative distances between
+each of the tones and the root
 """
 
 import bisect
@@ -126,9 +126,11 @@ class Scale(object):
         :param degree: the scale degree to retune
         :param cents: the number of cents by which to change the tone
         (can be negative)
-        :return:
+        :return: 0 on success, -1 on error
         """
         # FIXME: stub
+        if degree not in self.degrees:
+            return -1
         return
 
     def remove_degree(self, degree):
@@ -138,6 +140,8 @@ class Scale(object):
         :return: 0 on success, -1 on error
         """
         # FIXME: stub
+        if degree not in self.degrees:
+            return -1
         return
 
     @property

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -104,10 +104,11 @@ class Scale(object):
             i += 1
         return new_degree
 
-    def add_tone_above_degree(self, degree, cents):
+    def add_tone_rel_degree(self, degree, cents):
         """
-        Add a tone above an existing degree,
+        Add a tone relative to an existing degree,
         by the number of cents above the existing degree
+        (cents can be negative to insert below the degree)
         :param degree: existing degree of the scale
         :param cents: number of cents above the existing degree for new tone
         (can be negative to insert a tone below an existing degree)

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -24,7 +24,7 @@ class Scale(object):
         :param tones: List of tones, each tone the number of cents above root
         """
         # First degree is always the root
-        self.__degrees = {1: 0}
+        self.__degree_tones = {1: 0}
         self.__root_note = None
 
         self.root_note = root_note
@@ -35,10 +35,13 @@ class Scale(object):
             except TypeError:
                 pass
 
+    @property
+    def degree_tones(self):
+        return self.__degree_tones
 
     @property
     def degrees(self):
-        return self.__degrees
+        return sorted(list(self.degree_tones.keys()))
 
     @property
     def tones(self):
@@ -46,7 +49,7 @@ class Scale(object):
         Get the tones of the scale, in cents above root
         :return: A sorted list of tones in the scale
         """
-        return sorted(list(self.degrees.values()))
+        return sorted(list(self.degree_tones.values()))
 
     def add_tone(self, cents):
         """
@@ -70,9 +73,9 @@ class Scale(object):
         my_tones.append(cents)
         # Rebuild self.__degrees dictionary
         i = 1
-        self.__degrees = dict()
+        self.__degree_tones = dict()
         for tone in sorted(my_tones):
-            self.__degrees[i] = tone
+            self.__degree_tones[i] = tone
             if tone == cents:
                 new_degree = i
             i += 1

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -128,12 +128,23 @@ class Scale(object):
         (can be negative)
         :return: 0 on success, -1 on error
         """
-        # FIXME: stub
+        if degree == 1:
+            # can't remove the root
+            return -1
+        cur_deg_tones = self.degree_tones.copy()
         try:
             del self.__degree_tones[degree]
         except KeyError:
             return -1
-        return
+        new_cents = cur_deg_tones[degree] + cents
+        new_degree = self.add_tone(new_cents)
+        if new_degree is None or new_degree == -1:
+            # Re-tuned tone doesn't fit our scale constraints?
+            # reset degree_tones and return error
+            # FIXME: -1 means tone re-tuned to an existing tone, maybe that's ok?
+            self.__degree_tones = cur_deg_tones
+            return -1
+        return 0
 
     def remove_degree(self, degree):
         """

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -105,6 +105,14 @@ class Scale(object):
         return new_degree
 
     def add_tone_above_degree(self, degree, cents):
+        """
+        Add a tone above an existing degree,
+        by the number of cents above the existing degree
+        :param degree: existing degree of the scale
+        :param cents: number of cents above the existing degree for new tone
+        (can be negative to insert a tone below an existing degree)
+        :return: the degree of the inserted tone, -1 if error
+        """
         new_degree = None
         if degree not in self.degrees:
             return -1

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -37,10 +37,18 @@ class Scale(object):
 
     @property
     def degree_tones(self):
+        """
+        getter for __degree_tones
+        :return: dict of degree->tone, where tone is cents above root
+        """
         return self.__degree_tones
 
     @property
     def degrees(self):
+        """
+        The degrees of the scale
+        :return: A sorted list of the scale degrees
+        """
         return sorted(list(self.degree_tones.keys()))
 
     @property

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -129,7 +129,9 @@ class Scale(object):
         :return: 0 on success, -1 on error
         """
         # FIXME: stub
-        if degree not in self.degrees:
+        try:
+            del self.__degree_tones[degree]
+        except KeyError:
             return -1
         return
 
@@ -139,10 +141,16 @@ class Scale(object):
         :param degree:
         :return: 0 on success, -1 on error
         """
-        # FIXME: stub
-        if degree not in self.degrees:
+        try:
+            del self.__degree_tones[degree]
+        except KeyError:
             return -1
-        return
+        new_tones = self.tones
+        # Rebuild degree_tones
+        self.__degree_tones = dict()
+        for tone in new_tones:
+            self.add_tone(tone)
+        return 0
 
     @property
     def root_note(self):

--- a/lib/scale.py
+++ b/lib/scale.py
@@ -59,6 +59,20 @@ class Scale(object):
         """
         return sorted(list(self.degree_tones.values()))
 
+    @property
+    def degree_steps_cents(self):
+        """
+        Get the steps of every degree (to the previous), in cents
+        :return: dict of degree->cents to previous degree
+        """
+        steps = dict()
+        for degree, cents in self.degree_tones.items():
+            if degree == 1:
+                steps[1] = 0
+            else:
+                steps[degree] = cents - self.degree_tones[degree - 1]
+        return steps
+
     def add_tone(self, cents):
         """
         Add a tone to the scale

--- a/lib/scale_octave.py
+++ b/lib/scale_octave.py
@@ -7,7 +7,8 @@ Extends ./scale.py
 
 import scale
 
-OCTAVE_CENTS = 1200
+MAX_CENTS = 1200
+OCTAVE_CENTS = MAX_CENTS
 
 
 class ScaleOctave(scale.Scale):
@@ -31,6 +32,6 @@ class ScaleOctave(scale.Scale):
                  -1 if tone already exists in the scale
         Raises ValueError if cents out of range
         """
-        if cents > OCTAVE_CENTS:
+        if cents > MAX_CENTS:
             return None
         return super().add_tone(cents)

--- a/tests/test_all.bat
+++ b/tests/test_all.bat
@@ -1,0 +1,4 @@
+pytest -q test_note.py
+pytest -q test_scale.py
+pytest -q test_scale_octave.py
+pytest -q test_scale_12edo.py

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+pytest -q test_note.py
+pytest -q test_scale.py
+pytest -q test_scale_octave.py
+pytest -q test_scale_12edo.py

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -22,12 +22,17 @@ def test_scale_badroot_hz():
     with pytest.raises(ValueError):
         test = scale.Scale(root_note=-1)
 
+def test_scale_badroot_type():
+    test = scale.Scale(root_note='xyz')
+    assert test.root_note is None
+
 def test_scale_freq_change():
     test = scale.Scale(root_note=440)
     assert test.freq_ratio(660) == 1.5
 
 def test_scale_tone_0():
     test = scale.Scale()
+    assert list(test.degrees.keys()) == [1]
     assert test.tones == [0]
     test.add_tone(0)
     assert test.tones == [0]

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -69,3 +69,27 @@ def test_scale_degree_cents():
     assert test.degree_steps_cents == {
         1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
     }
+
+def test_add_tone_above_degree():
+    test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
+    retval = test.add_tone_above_degree(degree=3, cents=100)
+    assert retval == 4
+    assert test.degree_steps_cents == {
+        1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
+    }
+
+def test_add_tone_above_degree_jump():
+    test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
+    retval = test.add_tone_above_degree(degree=2, cents=300)
+    assert retval == 4
+    assert test.degree_steps_cents == {
+        1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
+    }
+
+def test_add_tone_above_bad_degree():
+    test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
+    retval = test.add_tone_above_degree(degree=9, cents=100)
+    assert retval == -1
+    assert test.degree_steps_cents == {
+        1: 0, 2: 200, 3: 200, 4: 300, 5: 200, 6: 200, 7: 100
+    }

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -35,6 +35,7 @@ def test_scale_tone_0():
     assert test.degrees == [1]
     assert test.tones == [0]
     test.add_tone(0)
+    assert test.degrees == [1]
     assert test.tones == [0]
 
 def test_scale_single_tones():
@@ -55,8 +56,10 @@ def test_scale_tones_array():
 
 def test_scale_bad_tone():
     test = scale.Scale(tones='bad')
+    assert test.degrees == [1]
     assert test.tones == [0]
 
 def test_scale_bad_tones_list():
     test = scale.Scale(tones=['bad', 2])
+    assert test.degrees == [1]
     assert test.tones == [0]

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -117,3 +117,19 @@ def test_add_tone_below_degree_too_far():
     assert test.degree_steps_cents == {
         1: 0, 2: 200, 3: 200, 4: 300, 5: 200, 6: 200, 7: 100
     }
+
+def test_scale_remove_degree():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    retval = test.remove_degree(3)
+    assert retval == 0
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7]
+    assert test.tones == [0, 200, 500, 700, 900, 1100, 1200]
+
+def test_scale_remove_degree_nonexist():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    retval = test.remove_degree(9)
+    assert retval == -1
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert test.tones == [0, 200, 400, 500, 700, 900, 1100, 1200]

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -63,3 +63,9 @@ def test_scale_bad_tones_list():
     test = scale.Scale(tones=['bad', 2])
     assert test.degrees == [1]
     assert test.tones == [0]
+
+def test_scale_degree_cents():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degree_steps_cents == {
+        1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
+    }

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -93,3 +93,27 @@ def test_add_tone_above_bad_degree():
     assert test.degree_steps_cents == {
         1: 0, 2: 200, 3: 200, 4: 300, 5: 200, 6: 200, 7: 100
     }
+
+def test_add_tone_below_degree():
+    test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
+    retval = test.add_tone_above_degree(degree=4, cents=-200)
+    assert retval == 4
+    assert test.degree_steps_cents == {
+        1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
+    }
+
+def test_add_tone_below_degree_jump():
+    test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
+    retval = test.add_tone_above_degree(degree=5, cents=-400)
+    assert retval == 4
+    assert test.degree_steps_cents == {
+        1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
+    }
+
+def test_add_tone_below_degree_too_far():
+    test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
+    retval = test.add_tone_above_degree(degree=4, cents=-800)
+    assert retval is None
+    assert test.degree_steps_cents == {
+        1: 0, 2: 200, 3: 200, 4: 300, 5: 200, 6: 200, 7: 100
+    }

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -41,12 +41,14 @@ def test_scale_single_tones():
     test = scale.Scale()
     for i in range(1,12):
         test.add_tone(i * 100)
+    assert test.degrees == list(range(1, 13))
     assert test.tones[8] == 800
     assert test.tones[0] == 0
     assert len(test.tones) == 12
 
 def test_scale_tones_array():
-    test = scale.Scale(tones=list(range(100,1200, 100)))
+    test = scale.Scale(tones=list(range(100, 1200, 100)))
+    assert test.degrees == list(range(1, 13))
     assert test.tones[8] == 800
     assert test.tones[0] == 0
     assert len(test.tones) == 12

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -72,7 +72,7 @@ def test_scale_degree_cents():
 
 def test_add_tone_above_degree():
     test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
-    retval = test.add_tone_above_degree(degree=3, cents=100)
+    retval = test.add_tone_rel_degree(degree=3, cents=100)
     assert retval == 4
     assert test.degree_steps_cents == {
         1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
@@ -80,7 +80,7 @@ def test_add_tone_above_degree():
 
 def test_add_tone_above_degree_jump():
     test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
-    retval = test.add_tone_above_degree(degree=2, cents=300)
+    retval = test.add_tone_rel_degree(degree=2, cents=300)
     assert retval == 4
     assert test.degree_steps_cents == {
         1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
@@ -88,7 +88,7 @@ def test_add_tone_above_degree_jump():
 
 def test_add_tone_above_bad_degree():
     test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
-    retval = test.add_tone_above_degree(degree=9, cents=100)
+    retval = test.add_tone_rel_degree(degree=9, cents=100)
     assert retval == -1
     assert test.degree_steps_cents == {
         1: 0, 2: 200, 3: 200, 4: 300, 5: 200, 6: 200, 7: 100
@@ -96,7 +96,7 @@ def test_add_tone_above_bad_degree():
 
 def test_add_tone_below_degree():
     test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
-    retval = test.add_tone_above_degree(degree=4, cents=-200)
+    retval = test.add_tone_rel_degree(degree=4, cents=-200)
     assert retval == 4
     assert test.degree_steps_cents == {
         1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
@@ -104,7 +104,7 @@ def test_add_tone_below_degree():
 
 def test_add_tone_below_degree_jump():
     test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
-    retval = test.add_tone_above_degree(degree=5, cents=-400)
+    retval = test.add_tone_rel_degree(degree=5, cents=-400)
     assert retval == 4
     assert test.degree_steps_cents == {
         1: 0, 2: 200, 3: 200, 4: 100, 5: 200, 6: 200, 7: 200, 8: 100
@@ -112,7 +112,7 @@ def test_add_tone_below_degree_jump():
 
 def test_add_tone_below_degree_too_far():
     test = scale.Scale(tones=[200, 400, 700, 900, 1100, 1200])
-    retval = test.add_tone_above_degree(degree=4, cents=-800)
+    retval = test.add_tone_rel_degree(degree=4, cents=-800)
     assert retval is None
     assert test.degree_steps_cents == {
         1: 0, 2: 200, 3: 200, 4: 300, 5: 200, 6: 200, 7: 100

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -133,3 +133,59 @@ def test_scale_remove_degree_nonexist():
     assert retval == -1
     assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
     assert test.tones == [0, 200, 400, 500, 700, 900, 1100, 1200]
+
+def test_move_degree_up():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    retval = test.move_degree(degree=2, cents=50)
+    assert retval == 0
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert test.tones == [0, 250, 400, 500, 700, 900, 1100, 1200]
+
+def test_move_degree_up_jump():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    retval = test.move_degree(degree=2, cents=250)
+    assert retval == 0
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert test.tones == [0, 400, 450, 500, 700, 900, 1100, 1200]
+
+def test_move_degree_down():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    retval = test.move_degree(degree=2, cents=-50)
+    assert retval == 0
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert test.tones == [0, 150, 400, 500, 700, 900, 1100, 1200]
+
+def test_move_degree_down_jump():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    retval = test.move_degree(degree=3, cents=-250)
+    assert retval == 0
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert test.tones == [0, 150, 200, 500, 700, 900, 1100, 1200]
+
+def test_move_degree_down_too_far():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    retval = test.move_degree(degree=2, cents=-500)
+    assert retval == -1
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert test.tones == [0, 200, 400, 500, 700, 900, 1100, 1200]
+
+def test_move_degree_nonexist():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    retval = test.move_degree(degree=9, cents=50)
+    assert retval == -1
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert test.tones == [0, 200, 400, 500, 700, 900, 1100, 1200]
+
+def test_move_degree_root():
+    test = scale.Scale(tones=[200, 400, 500, 700, 900, 1100, 1200])
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    retval = test.move_degree(degree=1, cents=50)
+    assert retval == -1
+    assert test.degrees == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert test.tones == [0, 200, 400, 500, 700, 900, 1100, 1200]

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -32,7 +32,7 @@ def test_scale_freq_change():
 
 def test_scale_tone_0():
     test = scale.Scale()
-    assert list(test.degrees.keys()) == [1]
+    assert test.degrees == [1]
     assert test.tones == [0]
     test.add_tone(0)
     assert test.tones == [0]

--- a/tests/test_scale_12edo.py
+++ b/tests/test_scale_12edo.py
@@ -9,33 +9,41 @@ WHOLE = SEMI * 2
 
 def test_scale_semitone():
     test = scale_12edo.Scale12EDO(tones=[SEMI])
+    assert test.degrees == [1, 2]
     assert test.tones == [0, SEMI]
 
 def test_scale_add_semitone():
     test = scale_12edo.Scale12EDO()
     assert test.tones == [0]
     retval = test.add_tone(SEMI)
-    assert retval == 1
+    assert retval == 2
+    assert test.degrees == [1, 2]
     assert test.tones == [0, SEMI]
 
 def test_scale_wholetone():
     test = scale_12edo.Scale12EDO(tones=[WHOLE])
+    assert test.degrees == [1, 2]
     assert test.tones == [0, WHOLE]
 
 def test_scale_add_wholetone():
     test = scale_12edo.Scale12EDO()
+    assert test.degrees == [1]
     assert test.tones == [0]
     retval = test.add_tone(WHOLE)
-    assert retval == 1
+    assert retval == 2
+    assert test.degrees == [1, 2]
     assert test.tones == [0, WHOLE]
 
 def test_scale_nontet():
     test = scale_12edo.Scale12EDO(tones=[101])
+    assert test.degrees == [1]
     assert test.tones == [0]
 
 def test_scale_add_nontet():
     test = scale_12edo.Scale12EDO()
+    assert test.degrees == [1]
     assert test.tones == [0]
     retval = test.add_tone(101)
     assert retval is None
+    assert test.degrees == [1]
     assert test.tones == [0]

--- a/tests/test_scale_12edo.py
+++ b/tests/test_scale_12edo.py
@@ -47,3 +47,21 @@ def test_scale_add_nontet():
     assert retval is None
     assert test.degrees == [1]
     assert test.tones == [0]
+
+def test_scale_insert_tone_overmax():
+    test = scale_12edo.Scale12EDO(tones=list(range(100, 1200, 100)))
+    retval = test.add_tone_rel_degree(degree=12, cents=200)
+    assert retval is None
+    assert test.degree_tones == {
+        1: 0, 2: 100, 3: 200, 4: 300, 5: 400, 6: 500, 7: 600, 8: 700,
+        9: 800, 10: 900, 11: 1000, 12: 1100
+    }
+
+def test_scale_insert_tone_nonet():
+    test = scale_12edo.Scale12EDO(tones=list(range(100, 1200, 100)))
+    retval = test.add_tone_rel_degree(degree=3, cents=111)
+    assert retval is None
+    assert test.degree_tones == {
+        1: 0, 2: 100, 3: 200, 4: 300, 5: 400, 6: 500, 7: 600, 8: 700,
+        9: 800, 10: 900, 11: 1000, 12: 1100
+    }

--- a/tests/test_scale_12edo.py
+++ b/tests/test_scale_12edo.py
@@ -65,3 +65,30 @@ def test_scale_insert_tone_nonet():
         1: 0, 2: 100, 3: 200, 4: 300, 5: 400, 6: 500, 7: 600, 8: 700,
         9: 800, 10: 900, 11: 1000, 12: 1100
     }
+
+def test_scale_move_tone_overmax():
+    test = scale_12edo.Scale12EDO(tones=list(range(100, 1200, 100)))
+    retval = test.move_degree(degree=12, cents=200)
+    assert retval == -1
+    assert test.degree_tones == {
+        1: 0, 2: 100, 3: 200, 4: 300, 5: 400, 6: 500, 7: 600, 8: 700,
+        9: 800, 10: 900, 11: 1000, 12: 1100
+    }
+
+def test_scale_move_tone_up_nonet():
+    test = scale_12edo.Scale12EDO(tones=list(range(100, 1200, 100)))
+    retval = test.move_degree(degree=3, cents=1)
+    assert retval == -1
+    assert test.degree_tones == {
+        1: 0, 2: 100, 3: 200, 4: 300, 5: 400, 6: 500, 7: 600, 8: 700,
+        9: 800, 10: 900, 11: 1000, 12: 1100
+    }
+
+def test_scale_move_tone_down_nonet():
+    test = scale_12edo.Scale12EDO(tones=list(range(100, 1200, 100)))
+    retval = test.move_degree(degree=3, cents=-1)
+    assert retval == -1
+    assert test.degree_tones == {
+        1: 0, 2: 100, 3: 200, 4: 300, 5: 400, 6: 500, 7: 600, 8: 700,
+        9: 800, 10: 900, 11: 1000, 12: 1100
+    }

--- a/tests/test_scale_octave.py
+++ b/tests/test_scale_octave.py
@@ -17,3 +17,12 @@ def test_scale_tone_overmax():
     assert retval is None
     assert test.degrees == [1]
     assert test.tones == [0]
+
+def test_scale_insert_tone_overmax():
+    test = scale_octave.ScaleOctave(tones=list(range(100, 1200, 100)))
+    retval = test.add_tone_rel_degree(degree=12, cents=200)
+    assert retval is None
+    assert test.degree_tones == {
+        1: 0, 2: 100, 3: 200, 4: 300, 5: 400, 6: 500, 7: 600, 8: 700,
+        9: 800, 10: 900, 11: 1000, 12: 1100
+    }

--- a/tests/test_scale_octave.py
+++ b/tests/test_scale_octave.py
@@ -26,3 +26,12 @@ def test_scale_insert_tone_overmax():
         1: 0, 2: 100, 3: 200, 4: 300, 5: 400, 6: 500, 7: 600, 8: 700,
         9: 800, 10: 900, 11: 1000, 12: 1100
     }
+
+def test_scale_move_tone_overmax():
+    test = scale_octave.ScaleOctave(tones=list(range(100, 1200, 100)))
+    retval = test.move_degree(degree=11, cents=201)
+    assert retval == -1
+    assert test.degree_tones == {
+        1: 0, 2: 100, 3: 200, 4: 300, 5: 400, 6: 500, 7: 600, 8: 700,
+        9: 800, 10: 900, 11: 1000, 12: 1100
+    }

--- a/tests/test_scale_octave.py
+++ b/tests/test_scale_octave.py
@@ -7,11 +7,13 @@ import scale_octave
 def test_scale_tone1200():
     test = scale_octave.ScaleOctave()
     retval = test.add_tone(1200)
-    assert retval == 1
+    assert retval == 2
+    assert test.degrees == [1, 2]
     assert test.tones == [0, 1200]
 
 def test_scale_tone_overmax():
     test = scale_octave.ScaleOctave()
     retval = test.add_tone(scale_octave.OCTAVE_CENTS + 1)
     assert retval is None
+    assert test.degrees == [1]
     assert test.tones == [0]


### PR DESCRIPTION
Rather than the "tones" array, make the base structure of the scale into a dict of degree->tone, the values of the dict being equivalent to the old tones array. This allows degrees (keys) to be a 1-based array rather than 0-based which I hope will be less confusing in the long run. Still a hassle to maintain when add/delete/move tones though, may look at replacing with a Pandas structure.